### PR TITLE
fix spec to make it work with quay.io and appr

### DIFF
--- a/appr.spec.yaml
+++ b/appr.spec.yaml
@@ -858,7 +858,7 @@ definitions:
         description: manifest-type
       created_at:
         type: string
-        format: date-time
+        pattern: '\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\d+'
         description: creation data
         title: created-at
       metadata:
@@ -935,11 +935,11 @@ definitions:
           description: List channels for that release
       created_at:
         type: string
-        format: date-time
+        pattern: '\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}.\d+'
         title: created_at
         description: Package creation date
       content:
-        $ref: "#/definitions/Manifest"
+        $ref: "#/definitions/OciDescriptor"
       package:
         type: string
         title: package-name

--- a/models/manifest.go
+++ b/models/manifest.go
@@ -23,8 +23,8 @@ type Manifest struct {
 	// created-at
 	//
 	// creation data
-	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	// Pattern: \d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\d+
+	CreatedAt string `json:"created_at,omitempty"`
 
 	// media-type
 	//
@@ -89,7 +89,7 @@ func (m *Manifest) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("created_at", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.Pattern("created_at", "body", string(m.CreatedAt), `\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\d+`); err != nil {
 		return err
 	}
 

--- a/models/package.go
+++ b/models/package.go
@@ -23,13 +23,13 @@ type Package struct {
 	Channels []string `json:"channels"`
 
 	// content
-	Content *Manifest `json:"content,omitempty"`
+	Content *OciDescriptor `json:"content,omitempty"`
 
 	// created_at
 	//
 	// Package creation date
-	// Format: date-time
-	CreatedAt strfmt.DateTime `json:"created_at,omitempty"`
+	// Pattern: \d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}.\d+
+	CreatedAt string `json:"created_at,omitempty"`
 
 	// media-type
 	//
@@ -89,7 +89,7 @@ func (m *Package) validateCreatedAt(formats strfmt.Registry) error {
 		return nil
 	}
 
-	if err := validate.FormatOf("created_at", "body", "date-time", m.CreatedAt.String(), formats); err != nil {
+	if err := validate.Pattern("created_at", "body", string(m.CreatedAt), `\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}.\d+`); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
- go-swagger throws an error since quay.io and appr do not return date-time in the expected format. pattern specifies the actual format of datetime in body of HTTP response.
- definitions/package have been changed to reflect the actual response of  ShowPackage API.